### PR TITLE
Adds convenience alias `invariantJsonResponse`

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,10 @@ const name = await formData.get('name')
 
 It's pretty simple. But honestly, it's nicer to read, it throws a special
 `InvariantError` object to distinguish it from other types of errors, and we
-have another useful utility for throwing `Response` objects instead of `Error`
-objects which is handy
-[in Remix](https://remix.run/docs/en/main/route/loader#throwing-responses-in-loaders).
+have another useful utility for throwing
+[`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) objects
+instead of `Error` objects which is handy [in
+Remix](https://remix.run/docs/en/main/route/loader#throwing-responses-in-loaders).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,38 @@ invariantResponse(
 )
 ```
 
+### `invariantJsonResponse`
+
+The `invariantJsonResponse` function is just an `invariantResponse` wrapper
+that doesn't accept a callback for the error message, just a plain string, and
+serializes it into a JSON object, throwing a `Response` with JSON content type
+and `400` status code, allowing us to reduce boilerplate for this particular
+case.
+
+**Basic Usage**
+
+```ts
+import { invariantJsonResponse } from '@epic-web/invariant'
+
+const value = 'someString'
+invariantResponse(typeof value === 'string', `'value' must be a string`)
+```
+
+Response received in case of false condition will have JSON body like this:
+```json
+{
+  "error": "'value' must be a string"
+}
+```
+
+**Throwing response with status different from default `400`**
+
+Optionally, you can pass a third numeric parameter to change the status code. Since the idea is to simplify the checking, this alias doesn't accepts full `Response` options, just a numeric status code.
+
+```ts
+invariantResponse(typeof value === 'string', `'value' must be a string`, 500)
+```
+
 ## Differences from [invariant](https://www.npmjs.com/package/invariant)
 
 There are three main differences. With `@epic-web/invariant`:
@@ -194,6 +226,8 @@ There are three main differences. With `@epic-web/invariant`:
 2. It's typesafe
 3. We support the common case (for Remix anyway) of throwing Responses as well
    with `invariantResponse`.
+4. Also for Remix, has convenience function `invariantJsonResponse` that throws
+   a Response with JSON content type.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ invariant(creature.type === 'Water', () => 'Creature must be of type Water')
 ### `invariantResponse`
 
 The `invariantResponse` function works similarly to `invariant`, but instead of
-throwing an `InvariantError`, it throws a Response object.
+throwing an `InvariantError`, it throws a `Response` object.
 
 **Basic Usage**
 
@@ -148,7 +148,7 @@ const creature = { name: 'Phoenix', type: 'Fire' }
 invariantResponse(creature.type === 'Fire', 'Creature must be of type Fire')
 ```
 
-**Throwing a Response on False Condition**
+**Throwing a `Response` on False Condition**
 
 ```ts
 import { invariantResponse } from '@epic-web/invariant'
@@ -161,7 +161,7 @@ invariantResponse(creature.type === 'Water', 'Creature must be of type Water')
 The response status default if 400 (Bad Request), but you'll find how to change
 that below.
 
-**Using Callback for Response Message**
+**Using Callback for `Response` Message**
 
 ```ts
 import { invariantResponse } from '@epic-web/invariant'
@@ -173,7 +173,7 @@ invariantResponse(
 )
 ```
 
-**Throwing a Response with Additional Options**
+**Throwing a `Response` with Additional Options**
 
 ```ts
 import { invariantResponse } from '@epic-web/invariant'

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,8 +34,6 @@ export function invariant(
  * Provide a condition and if that condition is falsey, this throws a 400
  * Response with the given message.
  *
- * inspired by invariant from 'tiny-invariant'
- *
  * @example
  * const creature = { name: 'Cerberus', type: 'Underworld' }
  * invariantResponse(

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,3 +60,29 @@ export function invariantResponse(
 		})
 	}
 }
+
+/**
+ * invariantResponse alias with defaults for convenience and to avoid boilerplate
+ *
+ * @examples
+ * invariantJsonResponse(typeof value === 'string', 'value must be a string')
+ * invariantJsonResponse(typeof value === 'string', 'value must be a string', 500)
+ *
+ * @param condition The condition to check
+ * @param message The message to throw
+ * @param status optional status code if different from 400
+ *
+ * @throws {Response} if condition is falsey
+ */
+export function invariantJsonResponse(
+	condition: any,
+	message: string,
+	status?: number,
+): asserts condition {
+	return invariantResponse(condition, JSON.stringify({ error: message }), {
+		status: status || 400,
+		headers: {
+			'Content-Type': 'text/json',
+		},
+	})
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,6 @@ export class InvariantError extends Error {
  *
  * @param condition The condition to check
  * @param message The message to throw (or a callback to generate the message)
- * @param responseInit Additional response init options if a response is thrown
  *
  * @throws {InvariantError} if condition is falsey
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,12 @@ export function invariant(
  * inspired by invariant from 'tiny-invariant'
  *
  * @example
- * invariantResponse(typeof value === 'string', `value must be a string`)
+ * const creature = { name: 'Cerberus', type: 'Underworld' }
+ * invariantResponse(
+ *  creature.type === 'Sky',
+ *  JSON.stringify({ error: 'Creature must be of type Sky' }),
+ *  { status: 500, headers: { 'Content-Type': 'text/json' } },
+ * )
  *
  * @param condition The condition to check
  * @param message The message to throw (or a callback to generate the message)


### PR DESCRIPTION
Fixes #3 

Note: comes from a branch named "Refactor invariant response" cause at first I thought I would refactor it. But then decided to provide a convenience alias and leave the original function as is.

This PR adds an `invariantJsonResponse` that's just a convenience function to wrap the provided message in a serialized JSON with the format:
```js
{
  error: message
}
```
and setting the proper content type to `text/json`.

Also it:
- removes the possibility to use a callback as a message
- instead of a ResponseInit object only accepts a status number

The idea is to have a convenience function to do a short and quick check of your values, if you need more machinery, then use the `invariantResponse`.

Includes a couple of commits that fix prior docstrings. (I don't know if "docstring" is the proper name)

I did the tests a little bit different:
- removed the assertion on the `try` section (TS was complaining about unreachable code)
- didn't set up values to check, I just sent `true` or `false`, as I wanted to test specifics and not the global inner working. Anyway, since it internally just calls `invariantResponse`, that's already tested.

I'm missing the README updates, but gotta sleep now. I'll update the PR tomorrow.