### PR TITLE
README example from text/json to application/json

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ const creature = { name: 'Cerberus', type: 'Underworld' }
 invariantResponse(
 	creature.type === 'Sky',
 	JSON.stringify({ error: 'Creature must be of type Sky' }),
-	{ status: 500, headers: { 'Content-Type': 'text/json' } },
+	{ status: 500, headers: { 'Content-Type': 'application/json' } },
 )
 ```
 


### PR DESCRIPTION
Not 100% sure why, but the following code (taken from the readme) in my remix application is not working as expected:

```javascript
  invariantResponse(
    someCondition,
    JSON.stringify({ message: "This collection is not compatible with the geobrowser" }),
    { status: 400, headers: { "Content-Type": "text/json" } },
  );
```

The error object I obtain contains an encoded string instead of an object itself.

Changing to more formal `application/json` fix the issue.